### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/app/models/contributor_to_item.rb
+++ b/app/models/contributor_to_item.rb
@@ -39,7 +39,7 @@ class ContributorToItem
 
   def doi_url
     return nil if @doi == nil
-    "http://dx.doi.org/#{@doi}"
+    "https://doi.org/#{@doi}"
   end
 
   def pub_med_url


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8).

Cheers!