### PR TITLE
Help flow update

### DIFF
--- a/app/views/home/faq.html.erb
+++ b/app/views/home/faq.html.erb
@@ -122,6 +122,10 @@
     <li>Anywhere else (weight: 1)</li>
     </ul>
     </p>
+
+    <h2>Who can I contact if I still have questions or technical issues?</h2>
+    <p>Email us at <a href="mailto:researchers@brown.edu">Researchers@brown.edu</a>.</p>
+
     <p>&nbsp;</p>
     <p>&nbsp;</p>
     <p>&nbsp;</p>

--- a/app/views/home/help.html.erb
+++ b/app/views/home/help.html.erb
@@ -51,7 +51,7 @@
 
     <li>
     <h3>Contact Us</h3>
-    <p>If you have any suggestions, problems, or questions you can submit
+    <p>If you have any suggestions, problems, or questions not addressed in the <a href="faq">FAQ</a> you can submit
       them to us via <a href="<%= contact_us_url() %>">this form</a>.
       We'd love to hear from you. You can also e-mail us directly at
       <a href="mailto:researchers@brown.edu">researchers@brown.edu</a> but please


### PR DESCRIPTION
Add extra language to Help page encouraging visiting the FAQ in front of the contact options. Add contact email to end of FAQ for questions not answered by FAQ. This is in preparation for/conjunction with changing the 'Problem Form' link in the manager interface to direct to the Help page instead.