### PR TITLE
Setup turnstile

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,8 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
 
+  before_action { |controller| BotDetectController.bot_detection_enforce_filter(controller) }
+
   def must_be_authenticated(format = nil)
     if !shibb_user?
       if format == "json"

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,8 +3,6 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
 
-  before_action { |controller| BotDetectController.bot_detection_enforce_filter(controller) }
-
   def must_be_authenticated(format = nil)
     if !shibb_user?
       if format == "json"

--- a/app/controllers/bot_detect_controller.rb
+++ b/app/controllers/bot_detect_controller.rb
@@ -216,6 +216,9 @@ class BotDetectController < ApplicationController
           SESSION_DATETIME_KEY => Time.now.utc.iso8601,
           SESSION_IP_KEY   => request.remote_ip
         }
+
+        Rails.logger.info("#{self.class.name}: Session datetime key: #{session[self.session_passed_key][SESSION_DATETIME_KEY]} Session IP Key: #{session[self.session_passed_key][SESSION_IP_KEY]}")
+
       else
         Rails.logger.info("#{self.class.name}: Result[success] is false")
         Rails.logger.warn("#{self.class.name}: Cloudflare Turnstile validation failed (#{request.remote_ip}, #{request.user_agent}): #{result}")

--- a/app/controllers/bot_detect_controller.rb
+++ b/app/controllers/bot_detect_controller.rb
@@ -256,7 +256,7 @@ def _bot_detect_passed_good?(request)
   # ip   = session_data[SESSION_IP_KEY]
 
   datetime = session_data[BotDetectController::SESSION_DATETIME_KEY]
-  datetime = session_data[BotDetectController::SESSION_IP_KEY]
+  ip = session_data[BotDetectController::SESSION_IP_KEY]
 
   (ip == request.remote_ip) && (Time.now - Time.iso8601(datetime) < self.session_passed_good_for )
 end

--- a/app/controllers/bot_detect_controller.rb
+++ b/app/controllers/bot_detect_controller.rb
@@ -245,15 +245,18 @@ class BotDetectController < ApplicationController
     end
   end
 
-# Does the session already contain a bot detect pass that is good for this request
-# Tie to IP address to prevent session replay shared among IPs
-def _bot_detect_passed_good?(request)
-  session_data = request.session[self.session_passed_key]
+  # Does the session already contain a bot detect pass that is good for this request
+  # Tie to IP address to prevent session replay shared among IPs
+  def _bot_detect_passed_good?(request)
+    session_data = request.session[self.session_passed_key]
 
-  return false unless session_data && session_data.kind_of?(Hash)
+    return false unless session_data && session_data.kind_of?(Hash)
 
-  datetime = session_data[SESSION_DATETIME_KEY]
-  ip   = session_data[SESSION_IP_KEY]
+    datetime = session_data[SESSION_DATETIME_KEY]
+    ip   = session_data[SESSION_IP_KEY]
 
-  (ip == request.remote_ip) && (Time.now - Time.iso8601(datetime) < self.session_passed_good_for )
-end
+    # datetime = session_data[self.session_passed_key][SESSION_DATETIME_KEY]
+    # datetime = session_data[self.session_passed_key][SESSION_IP_KEY]
+
+    (ip == request.remote_ip) && (Time.now - Time.iso8601(datetime) < self.session_passed_good_for )
+  end

--- a/app/controllers/bot_detect_controller.rb
+++ b/app/controllers/bot_detect_controller.rb
@@ -213,6 +213,8 @@ class BotDetectController < ApplicationController
       else
         Rails.logger.warn("#{self.class.name}: Cloudflare Turnstile validation failed (#{request.remote_ip}, #{request.user_agent}): #{result}")
       end
+
+      result["redirect_for_challenge"] = self.redirect_for_challenge
   
       # let's just return the whole thing to client? Is there anything confidential there?
       render json: result

--- a/app/controllers/bot_detect_controller.rb
+++ b/app/controllers/bot_detect_controller.rb
@@ -20,8 +20,8 @@ class BotDetectController < ApplicationController
 
   class_attribute :enabled, default: true # Must set to true to turn on at all
 
-  class_attribute :cf_turnstile_sitekey, default: "1x00000000000000000000AA" # a testing key that always passes
-  class_attribute :cf_turnstile_secret_key, default: "1x0000000000000000000000000000000AA" # a testing key always passes
+  class_attribute :cf_turnstile_sitekey, default: ENV["CF_TURNSTILE_SITEKEY"] # default: "1x00000000000000000000AA" # a testing key that always passes
+  class_attribute :cf_turnstile_secret_key, default: ENV["CF_TURNSTILE_SECRET_KEY"] # default: "1x0000000000000000000000000000000AA" # a testing key always passes
   # Turnstile testing keys: https://developers.cloudflare.com/turnstile/troubleshooting/testing/
 
   # up to rate_limit_count requests in rate_limit_period before challenged

--- a/app/controllers/bot_detect_controller.rb
+++ b/app/controllers/bot_detect_controller.rb
@@ -10,6 +10,9 @@
 #
 class BotDetectController < ApplicationController
 
+    SESSION_DATETIME_KEY = "t"
+    SESSION_IP_KEY = "i"
+
     # Config for bot detection is held here in class_attributes, kind of wonky, but it works
     #
     # These are defaults ready for extraction to a gem, in general here at Sci Hist if we want
@@ -182,6 +185,7 @@ class BotDetectController < ApplicationController
       require 'uri'
       require 'json'
       require 'time'
+
       Rails.logger.info("#{self.class.name}: Beginning of verify challenge")
 
       uri = URI('https://challenges.cloudflare.com/turnstile/v0/siteverify')

--- a/app/controllers/bot_detect_controller.rb
+++ b/app/controllers/bot_detect_controller.rb
@@ -182,6 +182,7 @@ class BotDetectController < ApplicationController
       require 'uri'
       require 'json'
       require 'time'
+      Rails.logger.info("#{self.class.name}: Beginning of verify challenge")
 
       uri = URI('https://challenges.cloudflare.com/turnstile/v0/siteverify')
       req = Net::HTTP::Post.new(uri)
@@ -191,9 +192,13 @@ class BotDetectController < ApplicationController
         'remoteip' => request.remote_ip
       })
 
+      Rails.logger.info("#{self.class.name}: Before making cloudflare call")
+
       res = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) do |http|
         http.request(req)
       end
+
+      Rails.logger.info("#{self.class.name}: After making cloudlfare call: #{res.code}")
     
       result = JSON.parse(res.body)
     
@@ -205,21 +210,25 @@ class BotDetectController < ApplicationController
         # mark it as succesful in session, and record time. They do need a session/cookies
         # to get through the challenge.
         # session[self.session_passed_key] = Time.now.utc.iso8601
+        Rails.logger.info("#{self.class.name}: Result[success] is true")
         Rails.logger.info("#{self.class.name}: Cloudflare Turnstile validation passed api (#{request.remote_ip}, #{request.user_agent}): #{params["dest"]}")
         session[self.session_passed_key] = {
           SESSION_DATETIME_KEY => Time.now.utc.iso8601,
           SESSION_IP_KEY   => request.remote_ip
         }
       else
+        Rails.logger.info("#{self.class.name}: Result[success] is false")
         Rails.logger.warn("#{self.class.name}: Cloudflare Turnstile validation failed (#{request.remote_ip}, #{request.user_agent}): #{result}")
       end
 
       result["redirect_for_challenge"] = self.redirect_for_challenge
   
       # let's just return the whole thing to client? Is there anything confidential there?
+      Rails.logger.info("#{self.class.name}: Returning response to frontend")
       render json: result
     rescue HTTP::Error, JSON::ParserError => e
       # probably an http timeout? or something weird.
+      Rails.logger.info("#{self.class.name}: Some random problem")
       Rails.logger.warn("#{self.class.name}: Cloudflare turnstile validation error (#{request.remote_ip}, #{request.user_agent}): #{e}: #{response&.body}")
       render json: {
         success: false,

--- a/app/controllers/bot_detect_controller.rb
+++ b/app/controllers/bot_detect_controller.rb
@@ -229,7 +229,7 @@ class BotDetectController < ApplicationController
       # let's just return the whole thing to client? Is there anything confidential there?
       Rails.logger.info("#{self.class.name}: Returning response to frontend")
       render json: result
-    rescue HTTP::Error, JSON::ParserError => e
+    rescue Exception => e
       # probably an http timeout? or something weird.
       Rails.logger.info("#{self.class.name}: Some random problem")
       Rails.logger.warn("#{self.class.name}: Cloudflare turnstile validation error (#{request.remote_ip}, #{request.user_agent}): #{e}: #{response&.body}")

--- a/app/controllers/bot_detect_controller.rb
+++ b/app/controllers/bot_detect_controller.rb
@@ -29,7 +29,7 @@ class BotDetectController < ApplicationController
   # class_attribute :rate_limit_count, default: 10
 
   # how long is a challenge pass good for before re-challenge?
-  class_attribute :session_passed_good_for, default: 1.minutes
+  class_attribute :session_passed_good_for, default: 24.hours
 
   # An array, can be:
   #   * a string, path prefix

--- a/app/controllers/bot_detect_controller.rb
+++ b/app/controllers/bot_detect_controller.rb
@@ -87,6 +87,7 @@ class BotDetectController < ApplicationController
   
     # key stored in Rails session object with channge passed confirmed
     class_attribute :session_passed_key, default: "bot_detection-passed"
+    class_attribute :redirect_for_challenge, default: true
   
     # key in rack env that says challenge is required
     # class_attribute :env_challenge_trigger_key, default: "bot_detect.should_challenge"

--- a/app/controllers/bot_detect_controller.rb
+++ b/app/controllers/bot_detect_controller.rb
@@ -252,11 +252,11 @@ class BotDetectController < ApplicationController
 
     return false unless session_data && session_data.kind_of?(Hash)
 
-    datetime = session_data[SESSION_DATETIME_KEY]
-    ip   = session_data[SESSION_IP_KEY]
+    # datetime = session_data[SESSION_DATETIME_KEY]
+    # ip   = session_data[SESSION_IP_KEY]
 
-    # datetime = session_data[self.session_passed_key][SESSION_DATETIME_KEY]
-    # datetime = session_data[self.session_passed_key][SESSION_IP_KEY]
+    datetime = session_data[self.session_passed_key][SESSION_DATETIME_KEY]
+    datetime = session_data[self.session_passed_key][SESSION_IP_KEY]
 
     (ip == request.remote_ip) && (Time.now - Time.iso8601(datetime) < self.session_passed_good_for )
   end

--- a/app/controllers/bot_detect_controller.rb
+++ b/app/controllers/bot_detect_controller.rb
@@ -1,0 +1,221 @@
+# This controller has actions for issuing a challenge page for CloudFlare Turnstile product,
+# and then redirecting back to desired page.
+#
+# It also includes logic for configuring rack attack and a Rails controller filter to enforce
+# redirection to these actions. All the logic related to bot detection with turnstile is
+# mostly in this file -- with very flexible configuration in class_attributes -- to faciliate
+# future extraction to a re-usable gem if desired.
+#
+# See more local docs at https://sciencehistory.atlassian.net/wiki/spaces/HDC/pages/2645098498/Cloudflare+Turnstile+bot+detection
+#
+class BotDetectController < ApplicationController
+
+    # Config for bot detection is held here in class_attributes, kind of wonky, but it works
+    #
+    # These are defaults ready for extraction to a gem, in general here at Sci Hist if we want
+    # to set config we do it in ./config/initializers/rack_attack.rb
+  
+    class_attribute :enabled, default: true # Must set to true to turn on at all
+  
+    class_attribute :cf_turnstile_sitekey, default: "1x00000000000000000000AA" # a testing key that always passes
+    class_attribute :cf_turnstile_secret_key, default: "1x0000000000000000000000000000000AA" # a testing key always passes
+    # Turnstile testing keys: https://developers.cloudflare.com/turnstile/troubleshooting/testing/
+  
+    # up to rate_limit_count requests in rate_limit_period before challenged
+    # class_attribute :rate_limit_period, default: 12.hour
+    # class_attribute :rate_limit_count, default: 10
+  
+    # how long is a challenge pass good for before re-challenge?
+    # class_attribute :session_passed_good_for, default: 24.hours
+  
+    # An array, can be:
+    #   * a string, path prefix
+    #   * a hash of rails route-decoded params, like `{ controller: "something" }`,
+    #     or `{ controller: "something", action: "index" }
+    #     The hash is more expensive to check and uses some not-technically-public
+    #     Rails api, but it's just so convenient.
+    #
+    # Used by default :location_matcher, if set custom may not be used
+    # class_attribute :rate_limited_locations, default: []
+  
+    # Executed at the _controller_ filter level, to last minute exempt certain
+    # actions from protection.
+    class_attribute :allow_exempt, default: ->(controller) { false }
+  
+  
+    # rate limit per subnet, following lehigh's lead, although we use a smaller
+    # subnet: /24 for IPv4, and /72 for IPv6
+    # https://git.drupalcode.org/project/turnstile_protect/-/blob/0dae9f95d48f9d8cae5a8e61e767c69f64490983/src/EventSubscriber/Challenge.php#L140-151
+    # class_attribute :rate_limit_discriminator, default: (lambda do |req|
+    #   if req.ip.index(":") # ipv6
+    #     IPAddr.new("#{req.ip}/24").to_string
+    #   else
+    #     IPAddr.new("#{req.ip}/72").to_string
+    #   end
+    # rescue IPAddr::InvalidAddressError
+    #   req.ip
+    # end)
+  
+    # class_attribute :location_matcher, default: ->(rack_req) {
+    #   parsed_route = nil
+    #   rate_limited_locations.any? do |val|
+    #     case val
+    #     when Hash
+    #       begin
+    #         # #recognize_path may e not techinically public API, and may be expensive, but
+    #         # no other way to do this, and it's mentioned in rack-attack:
+    #         # https://github.com/rack/rack-attack/blob/86650c4f7ea1af24fe4a89d3040e1309ee8a88bc/docs/advanced_configuration.md#match-actions-in-rails
+    #         # We do it lazily only if needed so if you don't want that don't use it.
+    #         parsed_route ||= rack_req.env["action_dispatch.routes"].recognize_path(rack_req.url, method: rack_req.request_method)
+    #         parsed_route && parsed_route >= val
+    #       rescue ActionController::RoutingError
+    #         false
+    #       end
+    #     when String
+    #       # string complete path at beginning, must end in ?, or end of string
+    #       /\A#{Regexp.escape val}(\/|\?|\Z)/ =~ rack_req.path
+    #     end
+    #   end
+    # }
+    class_attribute :cf_turnstile_js_url, default: "https://challenges.cloudflare.com/turnstile/v0/api.js"
+    class_attribute :cf_turnstile_validation_url, default:  "https://challenges.cloudflare.com/turnstile/v0/siteverify"
+    class_attribute :cf_timeout, default: 3 # max timeout seconds waiting on Cloudfront Turnstile api
+    helper_method :cf_turnstile_js_url, :cf_turnstile_sitekey
+  
+    # key stored in Rails session object with channge passed confirmed
+    # class_attribute :session_passed_key, default: "bot_detection-passed"
+  
+    # key in rack env that says challenge is required
+    # class_attribute :env_challenge_trigger_key, default: "bot_detect.should_challenge"
+  
+    # for allowing unsubscribe for testing
+    # class_attribute :_track_notification_subscription, instance_accessor: false
+  
+    # perhaps in an initializer, and after changing any config, run:
+    #
+    #     Rails.application.config.to_prepare do
+    #       BotDetectController.rack_attack_init
+    #     end
+    #
+    # Safe to call more than once if you change config and want to call again, say in testing.
+    # def self.rack_attack_init
+    #   self._rack_attack_uninit # make it safe for calling multiple times
+  
+    #   ## Turnstile bot detection throttling
+    #   #
+    #   # for paths matched by `rate_limited_locations`, after over rate_limit count requests in rate_limit_period,
+    #   # token will be stored in rack env instructing challenge is required.
+    #   #
+    #   # For actual challenge, need before_action in controller.
+    #   #
+    #   # You could rate limit detect on wider paths than you actually challenge on, or the same. You probably
+    #   # don't want to rate-limit detect on narrower list of paths than you challenge on!
+    #   Rack::Attack.track("bot_detect/rate_exceeded",
+    #       limit: self.rate_limit_count,
+    #       period: self.rate_limit_period) do |req|
+    #     if self.enabled && self.location_matcher.call(req)
+    #       self.rate_limit_discriminator.call(req)
+    #     end
+    #   end
+  
+    #   self._track_notification_subscription = ActiveSupport::Notifications.subscribe("track.rack_attack") do |_name, _start, _finish, request_id, payload|
+    #     rack_request = payload[:request]
+    #     rack_env     = rack_request.env
+    #     match_name = rack_env["rack.attack.matched"]  # name of rack-attack rule
+  
+    #     if match_name == "bot_detect/rate_exceeded"
+    #       match_data   = rack_env["rack.attack.match_data"]
+    #       match_data_formatted = match_data.slice(:count, :limit, :period).map { |k, v| "#{k}=#{v}"}.join(" ")
+    #       discriminator = rack_env["rack.attack.match_discriminator"] # unique key for rate limit, usually includes ip
+  
+    #       rack_env[self.env_challenge_trigger_key] = true
+    #     end
+    #   end
+    # end
+  
+    # def self._rack_attack_uninit
+    #   Rack::Attack.track("bot_detect/rate_exceeded") {} # overwrite track name with empty proc
+    #   ActiveSupport::Notifications.unsubscribe(self._track_notification_subscription) if self._track_notification_subscription
+    #   self._track_notification_subscription = nil
+    # end
+  
+    # Usually in your ApplicationController,
+    #
+    #     before_action { |controller| BotDetectController.bot_detection_enforce_filter(controller) }
+    def self.bot_detection_enforce_filter(controller)
+      if self.enabled &&
+        #   controller.request.env[self.env_challenge_trigger_key] &&
+        #   !controller.session[self.session_passed_key].try { |date| Time.now - Time.new(date) < self.session_passed_good_for } &&
+          !controller.kind_of?(self) && # don't ever guard ourself, that'd be a mess!
+          ! self.allow_exempt.call(controller)
+  
+        # we can only do GET requests right now
+        if !controller.request.get?
+          Rails.logger.warn("#{self}: Asked to protect request we could not, unprotected: #{controller.requet.method} #{controller.request.url}, (#{controller.request.remote_ip}, #{controller.request.user_agent})")
+          return
+        end
+  
+        Rails.logger.info("#{self.name}: Cloudflare Turnstile challenge redirect: (#{controller.request.remote_ip}, #{controller.request.user_agent}): from #{controller.request.url}")
+        # status code temporary
+        controller.redirect_to controller.bot_detect_challenge_path(dest: controller.request.original_fullpath), status: 307
+      end
+    end
+  
+  
+    def challenge
+    end
+  
+    def verify_challenge
+      # body = {
+      #   secret: self.cf_turnstile_secret_key,
+      #   response: params["cf_turnstile_response"],
+      #   remoteip: request.remote_ip
+      # }
+  
+      # Can't install http gem, so using built in ruby stuff
+    #   http = HTTP.timeout(self.cf_timeout)
+    #   response = http.post(self.cf_turnstile_validation_url,
+    #     json: body)
+
+      require 'net/http'
+      require 'uri'
+      require 'json'
+      require 'time'
+
+      uri = URI('https://challenges.cloudflare.com/turnstile/v0/siteverify')
+      req = Net::HTTP::Post.new(uri)
+      req.set_form_data({
+        'secret'   => self.cf_turnstile_secret_key,
+        'response' => params["cf_turnstile_response"],
+        'remoteip' => request.remote_ip
+      })
+
+      res = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) do |http|
+        http.request(req)
+      end
+    
+      result = JSON.parse(res.body)
+    
+      # result = response.parse
+      # {"success"=>true, "error-codes"=>[], "challenge_ts"=>"2025-01-06T17:44:28.544Z", "hostname"=>"example.com", "metadata"=>{"result_with_testing_key"=>true}}
+      # {"success"=>false, "error-codes"=>["invalid-input-response"], "messages"=>[], "metadata"=>{"result_with_testing_key"=>true}}
+  
+      if result["success"]
+        # mark it as succesful in session, and record time. They do need a session/cookies
+        # to get through the challenge.
+        # session[self.session_passed_key] = Time.now.utc.iso8601
+      else
+        Rails.logger.warn("#{self.class.name}: Cloudflare Turnstile validation failed (#{request.remote_ip}, #{request.user_agent}): #{result}")
+      end
+  
+      # let's just return the whole thing to client? Is there anything confidential there?
+      render json: result
+    rescue HTTP::Error, JSON::ParserError => e
+      # probably an http timeout? or something weird.
+      Rails.logger.warn("#{self.class.name}: Cloudflare turnstile validation error (#{request.remote_ip}, #{request.user_agent}): #{e}: #{response&.body}")
+      render json: {
+        success: false,
+        http_exception: e
+      }
+    end
+  end

--- a/app/controllers/bot_detect_controller.rb
+++ b/app/controllers/bot_detect_controller.rb
@@ -29,7 +29,7 @@ class BotDetectController < ApplicationController
   # class_attribute :rate_limit_count, default: 10
 
   # how long is a challenge pass good for before re-challenge?
-  class_attribute :session_passed_good_for, default: 24.hours
+  class_attribute :session_passed_good_for, default: 1.minutes
 
   # An array, can be:
   #   * a string, path prefix

--- a/app/controllers/bot_detect_controller.rb
+++ b/app/controllers/bot_detect_controller.rb
@@ -245,18 +245,18 @@ class BotDetectController < ApplicationController
     end
   end
 
-  # Does the session already contain a bot detect pass that is good for this request
-  # Tie to IP address to prevent session replay shared among IPs
-  def _bot_detect_passed_good?(request)
-    session_data = request.session[self.session_passed_key]
+# Does the session already contain a bot detect pass that is good for this request
+# Tie to IP address to prevent session replay shared among IPs
+def _bot_detect_passed_good?(request)
+  session_data = request.session[self.session_passed_key]
 
-    return false unless session_data && session_data.kind_of?(Hash)
+  return false unless session_data && session_data.kind_of?(Hash)
 
-    # datetime = session_data[SESSION_DATETIME_KEY]
-    # ip   = session_data[SESSION_IP_KEY]
+  # datetime = session_data[SESSION_DATETIME_KEY]
+  # ip   = session_data[SESSION_IP_KEY]
 
-    datetime = session_data[self.session_passed_key][SESSION_DATETIME_KEY]
-    datetime = session_data[self.session_passed_key][SESSION_IP_KEY]
+  datetime = session_data[BotDetectController::SESSION_DATETIME_KEY]
+  datetime = session_data[BotDetectController::SESSION_IP_KEY]
 
-    (ip == request.remote_ip) && (Time.now - Time.iso8601(datetime) < self.session_passed_good_for )
-  end
+  (ip == request.remote_ip) && (Time.now - Time.iso8601(datetime) < self.session_passed_good_for )
+end

--- a/app/controllers/bot_detect_controller.rb
+++ b/app/controllers/bot_detect_controller.rb
@@ -10,230 +10,230 @@
 #
 class BotDetectController < ApplicationController
 
-    SESSION_DATETIME_KEY = "t"
-    SESSION_IP_KEY = "i"
+  SESSION_DATETIME_KEY = "t"
+  SESSION_IP_KEY = "i"
 
-    # Config for bot detection is held here in class_attributes, kind of wonky, but it works
-    #
-    # These are defaults ready for extraction to a gem, in general here at Sci Hist if we want
-    # to set config we do it in ./config/initializers/rack_attack.rb
-  
-    class_attribute :enabled, default: true # Must set to true to turn on at all
-  
-    class_attribute :cf_turnstile_sitekey, default: "1x00000000000000000000AA" # a testing key that always passes
-    class_attribute :cf_turnstile_secret_key, default: "1x0000000000000000000000000000000AA" # a testing key always passes
-    # Turnstile testing keys: https://developers.cloudflare.com/turnstile/troubleshooting/testing/
-  
-    # up to rate_limit_count requests in rate_limit_period before challenged
-    # class_attribute :rate_limit_period, default: 12.hour
-    # class_attribute :rate_limit_count, default: 10
-  
-    # how long is a challenge pass good for before re-challenge?
-    class_attribute :session_passed_good_for, default: 24.hours
-  
-    # An array, can be:
-    #   * a string, path prefix
-    #   * a hash of rails route-decoded params, like `{ controller: "something" }`,
-    #     or `{ controller: "something", action: "index" }
-    #     The hash is more expensive to check and uses some not-technically-public
-    #     Rails api, but it's just so convenient.
-    #
-    # Used by default :location_matcher, if set custom may not be used
-    # class_attribute :rate_limited_locations, default: []
-  
-    # Executed at the _controller_ filter level, to last minute exempt certain
-    # actions from protection.
-    class_attribute :allow_exempt, default: ->(controller) { false }
-  
-  
-    # rate limit per subnet, following lehigh's lead, although we use a smaller
-    # subnet: /24 for IPv4, and /72 for IPv6
-    # https://git.drupalcode.org/project/turnstile_protect/-/blob/0dae9f95d48f9d8cae5a8e61e767c69f64490983/src/EventSubscriber/Challenge.php#L140-151
-    # class_attribute :rate_limit_discriminator, default: (lambda do |req|
-    #   if req.ip.index(":") # ipv6
-    #     IPAddr.new("#{req.ip}/24").to_string
-    #   else
-    #     IPAddr.new("#{req.ip}/72").to_string
-    #   end
-    # rescue IPAddr::InvalidAddressError
-    #   req.ip
-    # end)
-  
-    # class_attribute :location_matcher, default: ->(rack_req) {
-    #   parsed_route = nil
-    #   rate_limited_locations.any? do |val|
-    #     case val
-    #     when Hash
-    #       begin
-    #         # #recognize_path may e not techinically public API, and may be expensive, but
-    #         # no other way to do this, and it's mentioned in rack-attack:
-    #         # https://github.com/rack/rack-attack/blob/86650c4f7ea1af24fe4a89d3040e1309ee8a88bc/docs/advanced_configuration.md#match-actions-in-rails
-    #         # We do it lazily only if needed so if you don't want that don't use it.
-    #         parsed_route ||= rack_req.env["action_dispatch.routes"].recognize_path(rack_req.url, method: rack_req.request_method)
-    #         parsed_route && parsed_route >= val
-    #       rescue ActionController::RoutingError
-    #         false
-    #       end
-    #     when String
-    #       # string complete path at beginning, must end in ?, or end of string
-    #       /\A#{Regexp.escape val}(\/|\?|\Z)/ =~ rack_req.path
-    #     end
-    #   end
-    # }
-    class_attribute :cf_turnstile_js_url, default: "https://challenges.cloudflare.com/turnstile/v0/api.js"
-    class_attribute :cf_turnstile_validation_url, default:  "https://challenges.cloudflare.com/turnstile/v0/siteverify"
-    class_attribute :cf_timeout, default: 3 # max timeout seconds waiting on Cloudfront Turnstile api
-    helper_method :cf_turnstile_js_url, :cf_turnstile_sitekey
-  
-    # key stored in Rails session object with channge passed confirmed
-    class_attribute :session_passed_key, default: "bot_detection-passed"
-    class_attribute :redirect_for_challenge, default: true
-  
-    # key in rack env that says challenge is required
-    # class_attribute :env_challenge_trigger_key, default: "bot_detect.should_challenge"
-  
-    # for allowing unsubscribe for testing
-    # class_attribute :_track_notification_subscription, instance_accessor: false
-  
-    # perhaps in an initializer, and after changing any config, run:
-    #
-    #     Rails.application.config.to_prepare do
-    #       BotDetectController.rack_attack_init
-    #     end
-    #
-    # Safe to call more than once if you change config and want to call again, say in testing.
-    # def self.rack_attack_init
-    #   self._rack_attack_uninit # make it safe for calling multiple times
-  
-    #   ## Turnstile bot detection throttling
-    #   #
-    #   # for paths matched by `rate_limited_locations`, after over rate_limit count requests in rate_limit_period,
-    #   # token will be stored in rack env instructing challenge is required.
-    #   #
-    #   # For actual challenge, need before_action in controller.
-    #   #
-    #   # You could rate limit detect on wider paths than you actually challenge on, or the same. You probably
-    #   # don't want to rate-limit detect on narrower list of paths than you challenge on!
-    #   Rack::Attack.track("bot_detect/rate_exceeded",
-    #       limit: self.rate_limit_count,
-    #       period: self.rate_limit_period) do |req|
-    #     if self.enabled && self.location_matcher.call(req)
-    #       self.rate_limit_discriminator.call(req)
-    #     end
-    #   end
-  
-    #   self._track_notification_subscription = ActiveSupport::Notifications.subscribe("track.rack_attack") do |_name, _start, _finish, request_id, payload|
-    #     rack_request = payload[:request]
-    #     rack_env     = rack_request.env
-    #     match_name = rack_env["rack.attack.matched"]  # name of rack-attack rule
-  
-    #     if match_name == "bot_detect/rate_exceeded"
-    #       match_data   = rack_env["rack.attack.match_data"]
-    #       match_data_formatted = match_data.slice(:count, :limit, :period).map { |k, v| "#{k}=#{v}"}.join(" ")
-    #       discriminator = rack_env["rack.attack.match_discriminator"] # unique key for rate limit, usually includes ip
-  
-    #       rack_env[self.env_challenge_trigger_key] = true
-    #     end
-    #   end
-    # end
-  
-    # def self._rack_attack_uninit
-    #   Rack::Attack.track("bot_detect/rate_exceeded") {} # overwrite track name with empty proc
-    #   ActiveSupport::Notifications.unsubscribe(self._track_notification_subscription) if self._track_notification_subscription
-    #   self._track_notification_subscription = nil
-    # end
-  
-    # Usually in your ApplicationController,
-    #
-    #     before_action { |controller| BotDetectController.bot_detection_enforce_filter(controller) }
-    def self.bot_detection_enforce_filter(controller)
-      if self.enabled &&
-        #   controller.request.env[self.env_challenge_trigger_key] &&
-        #   !controller.session[self.session_passed_key].try { |date| Time.now - Time.new(date) < self.session_passed_good_for } &&
-        !controller.kind_of?(self) && # don't ever guard ourself, that'd be a mess!
-        ! self._bot_detect_passed_good?(controller.request) &&
-        ! self.allow_exempt.call(controller)
-  
-        # we can only do GET requests right now
-        if !controller.request.get?
-          Rails.logger.warn("#{self}: Asked to protect request we could not, unprotected: #{controller.request.method} #{controller.request.url}, (#{controller.request.remote_ip}, #{controller.request.user_agent})")
-          return
-        end
-  
-        Rails.logger.info("#{self.name}: Cloudflare Turnstile challenge redirect: (#{controller.request.remote_ip}, #{controller.request.user_agent}): from #{controller.request.url}")
-        # status code temporary
-        controller.redirect_to controller.bot_detect_challenge_path(dest: controller.request.original_fullpath), status: 307
+  # Config for bot detection is held here in class_attributes, kind of wonky, but it works
+  #
+  # These are defaults ready for extraction to a gem, in general here at Sci Hist if we want
+  # to set config we do it in ./config/initializers/rack_attack.rb
+
+  class_attribute :enabled, default: true # Must set to true to turn on at all
+
+  class_attribute :cf_turnstile_sitekey, default: "1x00000000000000000000AA" # a testing key that always passes
+  class_attribute :cf_turnstile_secret_key, default: "1x0000000000000000000000000000000AA" # a testing key always passes
+  # Turnstile testing keys: https://developers.cloudflare.com/turnstile/troubleshooting/testing/
+
+  # up to rate_limit_count requests in rate_limit_period before challenged
+  # class_attribute :rate_limit_period, default: 12.hour
+  # class_attribute :rate_limit_count, default: 10
+
+  # how long is a challenge pass good for before re-challenge?
+  class_attribute :session_passed_good_for, default: 24.hours
+
+  # An array, can be:
+  #   * a string, path prefix
+  #   * a hash of rails route-decoded params, like `{ controller: "something" }`,
+  #     or `{ controller: "something", action: "index" }
+  #     The hash is more expensive to check and uses some not-technically-public
+  #     Rails api, but it's just so convenient.
+  #
+  # Used by default :location_matcher, if set custom may not be used
+  # class_attribute :rate_limited_locations, default: []
+
+  # Executed at the _controller_ filter level, to last minute exempt certain
+  # actions from protection.
+  class_attribute :allow_exempt, default: ->(controller) { false }
+
+
+  # rate limit per subnet, following lehigh's lead, although we use a smaller
+  # subnet: /24 for IPv4, and /72 for IPv6
+  # https://git.drupalcode.org/project/turnstile_protect/-/blob/0dae9f95d48f9d8cae5a8e61e767c69f64490983/src/EventSubscriber/Challenge.php#L140-151
+  # class_attribute :rate_limit_discriminator, default: (lambda do |req|
+  #   if req.ip.index(":") # ipv6
+  #     IPAddr.new("#{req.ip}/24").to_string
+  #   else
+  #     IPAddr.new("#{req.ip}/72").to_string
+  #   end
+  # rescue IPAddr::InvalidAddressError
+  #   req.ip
+  # end)
+
+  # class_attribute :location_matcher, default: ->(rack_req) {
+  #   parsed_route = nil
+  #   rate_limited_locations.any? do |val|
+  #     case val
+  #     when Hash
+  #       begin
+  #         # #recognize_path may e not techinically public API, and may be expensive, but
+  #         # no other way to do this, and it's mentioned in rack-attack:
+  #         # https://github.com/rack/rack-attack/blob/86650c4f7ea1af24fe4a89d3040e1309ee8a88bc/docs/advanced_configuration.md#match-actions-in-rails
+  #         # We do it lazily only if needed so if you don't want that don't use it.
+  #         parsed_route ||= rack_req.env["action_dispatch.routes"].recognize_path(rack_req.url, method: rack_req.request_method)
+  #         parsed_route && parsed_route >= val
+  #       rescue ActionController::RoutingError
+  #         false
+  #       end
+  #     when String
+  #       # string complete path at beginning, must end in ?, or end of string
+  #       /\A#{Regexp.escape val}(\/|\?|\Z)/ =~ rack_req.path
+  #     end
+  #   end
+  # }
+  class_attribute :cf_turnstile_js_url, default: "https://challenges.cloudflare.com/turnstile/v0/api.js"
+  class_attribute :cf_turnstile_validation_url, default:  "https://challenges.cloudflare.com/turnstile/v0/siteverify"
+  class_attribute :cf_timeout, default: 3 # max timeout seconds waiting on Cloudfront Turnstile api
+  helper_method :cf_turnstile_js_url, :cf_turnstile_sitekey
+
+  # key stored in Rails session object with channge passed confirmed
+  class_attribute :session_passed_key, default: "bot_detection-passed"
+  class_attribute :redirect_for_challenge, default: true
+
+  # key in rack env that says challenge is required
+  # class_attribute :env_challenge_trigger_key, default: "bot_detect.should_challenge"
+
+  # for allowing unsubscribe for testing
+  # class_attribute :_track_notification_subscription, instance_accessor: false
+
+  # perhaps in an initializer, and after changing any config, run:
+  #
+  #     Rails.application.config.to_prepare do
+  #       BotDetectController.rack_attack_init
+  #     end
+  #
+  # Safe to call more than once if you change config and want to call again, say in testing.
+  # def self.rack_attack_init
+  #   self._rack_attack_uninit # make it safe for calling multiple times
+
+  #   ## Turnstile bot detection throttling
+  #   #
+  #   # for paths matched by `rate_limited_locations`, after over rate_limit count requests in rate_limit_period,
+  #   # token will be stored in rack env instructing challenge is required.
+  #   #
+  #   # For actual challenge, need before_action in controller.
+  #   #
+  #   # You could rate limit detect on wider paths than you actually challenge on, or the same. You probably
+  #   # don't want to rate-limit detect on narrower list of paths than you challenge on!
+  #   Rack::Attack.track("bot_detect/rate_exceeded",
+  #       limit: self.rate_limit_count,
+  #       period: self.rate_limit_period) do |req|
+  #     if self.enabled && self.location_matcher.call(req)
+  #       self.rate_limit_discriminator.call(req)
+  #     end
+  #   end
+
+  #   self._track_notification_subscription = ActiveSupport::Notifications.subscribe("track.rack_attack") do |_name, _start, _finish, request_id, payload|
+  #     rack_request = payload[:request]
+  #     rack_env     = rack_request.env
+  #     match_name = rack_env["rack.attack.matched"]  # name of rack-attack rule
+
+  #     if match_name == "bot_detect/rate_exceeded"
+  #       match_data   = rack_env["rack.attack.match_data"]
+  #       match_data_formatted = match_data.slice(:count, :limit, :period).map { |k, v| "#{k}=#{v}"}.join(" ")
+  #       discriminator = rack_env["rack.attack.match_discriminator"] # unique key for rate limit, usually includes ip
+
+  #       rack_env[self.env_challenge_trigger_key] = true
+  #     end
+  #   end
+  # end
+
+  # def self._rack_attack_uninit
+  #   Rack::Attack.track("bot_detect/rate_exceeded") {} # overwrite track name with empty proc
+  #   ActiveSupport::Notifications.unsubscribe(self._track_notification_subscription) if self._track_notification_subscription
+  #   self._track_notification_subscription = nil
+  # end
+
+  # Usually in your ApplicationController,
+  #
+  #     before_action { |controller| BotDetectController.bot_detection_enforce_filter(controller) }
+  def self.bot_detection_enforce_filter(controller)
+    if self.enabled &&
+      #   controller.request.env[self.env_challenge_trigger_key] &&
+      #   !controller.session[self.session_passed_key].try { |date| Time.now - Time.new(date) < self.session_passed_good_for } &&
+      !controller.kind_of?(self) && # don't ever guard ourself, that'd be a mess!
+      ! self._bot_detect_passed_good?(controller.request) &&
+      ! self.allow_exempt.call(controller)
+
+      # we can only do GET requests right now
+      if !controller.request.get?
+        Rails.logger.warn("#{self}: Asked to protect request we could not, unprotected: #{controller.request.method} #{controller.request.url}, (#{controller.request.remote_ip}, #{controller.request.user_agent})")
+        return
       end
+
+      Rails.logger.info("#{self.name}: Cloudflare Turnstile challenge redirect: (#{controller.request.remote_ip}, #{controller.request.user_agent}): from #{controller.request.url}")
+      # status code temporary
+      controller.redirect_to controller.bot_detect_challenge_path(dest: controller.request.original_fullpath), status: 307
     end
-  
-  
-    def challenge
-    end
-  
-    def verify_challenge
-      # body = {
-      #   secret: self.cf_turnstile_secret_key,
-      #   response: params["cf_turnstile_response"],
-      #   remoteip: request.remote_ip
-      # }
-  
-      # Can't install http gem, so using built in ruby stuff
+  end
+
+
+  def challenge
+  end
+
+  def verify_challenge
+    # body = {
+    #   secret: self.cf_turnstile_secret_key,
+    #   response: params["cf_turnstile_response"],
+    #   remoteip: request.remote_ip
+    # }
+
+    # Can't install http gem, so using built in ruby stuff
     #   http = HTTP.timeout(self.cf_timeout)
     #   response = http.post(self.cf_turnstile_validation_url,
     #     json: body)
 
-      require 'net/http'
-      require 'uri'
-      require 'json'
-      require 'time'
+    require 'net/http'
+    require 'uri'
+    require 'json'
+    require 'time'
 
-      Rails.logger.info("#{self.class.name}: Beginning of verify challenge")
+    Rails.logger.info("#{self.class.name}: Beginning of verify challenge")
 
-      uri = URI('https://challenges.cloudflare.com/turnstile/v0/siteverify')
-      req = Net::HTTP::Post.new(uri)
-      req.set_form_data({
-        'secret'   => self.cf_turnstile_secret_key,
-        'response' => params["cf_turnstile_response"],
-        'remoteip' => request.remote_ip
-      })
+    uri = URI('https://challenges.cloudflare.com/turnstile/v0/siteverify')
+    req = Net::HTTP::Post.new(uri)
+    req.set_form_data({
+      'secret'   => self.cf_turnstile_secret_key,
+      'response' => params["cf_turnstile_response"],
+      'remoteip' => request.remote_ip
+    })
 
-      Rails.logger.info("#{self.class.name}: Before making cloudflare call")
+    Rails.logger.info("#{self.class.name}: Before making cloudflare call")
 
-      res = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) do |http|
-        http.request(req)
-      end
+    res = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) do |http|
+      http.request(req)
+    end
 
-      Rails.logger.info("#{self.class.name}: After making cloudlfare call: #{res.code}")
-    
-      result = JSON.parse(res.body)
-    
-      # result = response.parse
-      # {"success"=>true, "error-codes"=>[], "challenge_ts"=>"2025-01-06T17:44:28.544Z", "hostname"=>"example.com", "metadata"=>{"result_with_testing_key"=>true}}
-      # {"success"=>false, "error-codes"=>["invalid-input-response"], "messages"=>[], "metadata"=>{"result_with_testing_key"=>true}}
+    Rails.logger.info("#{self.class.name}: After making cloudlfare call: #{res.code}")
   
-      if result["success"]
-        # mark it as succesful in session, and record time. They do need a session/cookies
-        # to get through the challenge.
-        # session[self.session_passed_key] = Time.now.utc.iso8601
-        Rails.logger.info("#{self.class.name}: Result[success] is true")
-        Rails.logger.info("#{self.class.name}: Cloudflare Turnstile validation passed api (#{request.remote_ip}, #{request.user_agent}): #{params["dest"]}")
-        session[self.session_passed_key] = {
-          SESSION_DATETIME_KEY => Time.now.utc.iso8601,
-          SESSION_IP_KEY   => request.remote_ip
-        }
-
-        Rails.logger.info("#{self.class.name}: Session datetime key: #{session[self.session_passed_key][SESSION_DATETIME_KEY]} Session IP Key: #{session[self.session_passed_key][SESSION_IP_KEY]}")
-
-      else
-        Rails.logger.info("#{self.class.name}: Result[success] is false")
-        Rails.logger.warn("#{self.class.name}: Cloudflare Turnstile validation failed (#{request.remote_ip}, #{request.user_agent}): #{result}")
-      end
-
-      result["redirect_for_challenge"] = self.redirect_for_challenge
+    result = JSON.parse(res.body)
   
-      # let's just return the whole thing to client? Is there anything confidential there?
-      Rails.logger.info("#{self.class.name}: Returning response to frontend")
-      render json: result
+    # result = response.parse
+    # {"success"=>true, "error-codes"=>[], "challenge_ts"=>"2025-01-06T17:44:28.544Z", "hostname"=>"example.com", "metadata"=>{"result_with_testing_key"=>true}}
+    # {"success"=>false, "error-codes"=>["invalid-input-response"], "messages"=>[], "metadata"=>{"result_with_testing_key"=>true}}
+
+    if result["success"]
+      # mark it as succesful in session, and record time. They do need a session/cookies
+      # to get through the challenge.
+      # session[self.session_passed_key] = Time.now.utc.iso8601
+      Rails.logger.info("#{self.class.name}: Result[success] is true")
+      Rails.logger.info("#{self.class.name}: Cloudflare Turnstile validation passed api (#{request.remote_ip}, #{request.user_agent}): #{params["dest"]}")
+      session[self.session_passed_key] = {
+        SESSION_DATETIME_KEY => Time.now.utc.iso8601,
+        SESSION_IP_KEY   => request.remote_ip
+      }
+
+      Rails.logger.info("#{self.class.name}: Session datetime key: #{session[self.session_passed_key][SESSION_DATETIME_KEY]} Session IP Key: #{session[self.session_passed_key][SESSION_IP_KEY]}")
+
+    else
+      Rails.logger.info("#{self.class.name}: Result[success] is false")
+      Rails.logger.warn("#{self.class.name}: Cloudflare Turnstile validation failed (#{request.remote_ip}, #{request.user_agent}): #{result}")
+    end
+
+    result["redirect_for_challenge"] = self.redirect_for_challenge
+
+    # let's just return the whole thing to client? Is there anything confidential there?
+    Rails.logger.info("#{self.class.name}: Returning response to frontend")
+    render json: result
     rescue Exception => e
       # probably an http timeout? or something weird.
       Rails.logger.info("#{self.class.name}: Some random problem")

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -2,6 +2,9 @@
 
 class SearchController < ApplicationController
   # Advanced search.
+
+  before_action { |controller| BotDetectController.bot_detection_enforce_filter(controller) }
+
   def advanced
     q = build_q_from_params()
     if params["search"] == "true" && q != ""

--- a/app/views/bot_detect/challenge.html.erb
+++ b/app/views/bot_detect/challenge.html.erb
@@ -1,0 +1,67 @@
+<% content_for(:head) do %>
+    <script src="<%= cf_turnstile_js_url %>" async defer></script>
+    <meta name="robots" content="noindex">
+  <% end %>
+  
+  
+  <h1 class="brand-alt-h1 mb-4">Traffic control and bot detection...</h2>
+  
+  <div
+    class="cf-turnstile"
+    data-sitekey="<%= cf_turnstile_sitekey %>"
+    data-callback="turnstileCallback"
+  ></div>
+  
+  <noscript>
+    <div class="alert alert-danger">Sorry, Javascript is required to be enabled for our traffic check, and does not appear available.</div>
+  </noscript>
+  
+  <p>We strive to make our content freely available. If this check is preventing you from making use of our resources, make sure you have cookies enabled. If you still have trouble, please <a href="mailto:digital@sciencehistory.org">get in touch</a>. You can also take a look at our information on <a href="https://digital.sciencehistory.org/api_docs">API and Machine Access</a>.</p>
+  
+  <script type="text/javascript">
+    async function turnstileCallback(token) {
+      try {
+        // I don't know if we should be disabling CSRF for this one, but we'll just use it
+        const csrfToken = document.querySelector("[name='csrf-token']");
+  
+        const response = await fetch('<%= bot_detect_challenge_path %>', {
+          method: 'POST',
+          headers: {
+            "X-CSRF-Token": csrfToken?.content,
+            "Content-Type": "application/json"
+          },
+          body: JSON.stringify({ cf_turnstile_response: token }),
+        });
+  
+        if (!response.ok) {
+          throw new Error('bad response: ' + response.status + ": " + response.url);
+        }
+  
+        result = await response.json();
+        if (result["success"] == true) {
+          const dest = new URLSearchParams(window.location.search).get("dest");
+          // For security make sure it only has path and on
+          if (!dest.startsWith("/") || dest.startsWith("//")) {
+            throw new Error("illegal non-local redirect: " + dest);
+          }
+          // replace the challenge page in history
+          window.location.replace(dest);
+        } else {
+          console.error("Turnstile response reported as failure: " + JSON.stringify(result))
+          _displayChallengeError();
+        }
+      } catch(error) {
+        console.error("Error processing turnstile challenge backend action: " + error);
+        _displayChallengeError();
+      }
+    }
+  
+    function _displayChallengeError() {
+      document.querySelector(".cf-turnstile").outerHTML = `
+        <div class="alert alert-danger" role="alert">
+          <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
+          Check failed. Sorry, something has gone wrong, or your traffic looks unusual to us. You can try refreshing this page to try again.
+        </div>
+      `;
+    }
+  </script>

--- a/app/views/bot_detect/challenge.html.erb
+++ b/app/views/bot_detect/challenge.html.erb
@@ -39,13 +39,14 @@
   
       result = await response.json();
       if (result["redirect_for_challenge"] == true) {
+        console.error("Hello Connor")
         const dest = new URLSearchParams(window.location.search).get("dest");
         // For security make sure it only has path and on
         if (!dest.startsWith("/") || dest.startsWith("//")) {
           throw new Error("illegal non-local redirect: " + dest);
         }
 
-        console.log('Hello Connor')
+        console.error("before window.location.replace")
 
         // replace the challenge page in history
         window.location.replace(dest);

--- a/app/views/bot_detect/challenge.html.erb
+++ b/app/views/bot_detect/challenge.html.erb
@@ -44,6 +44,9 @@
         if (!dest.startsWith("/") || dest.startsWith("//")) {
           throw new Error("illegal non-local redirect: " + dest);
         }
+
+        console.log('Hello Connor')
+
         // replace the challenge page in history
         window.location.replace(dest);
       } else {

--- a/app/views/bot_detect/challenge.html.erb
+++ b/app/views/bot_detect/challenge.html.erb
@@ -20,13 +20,9 @@
   
 <script type="text/javascript">
   async function turnstileCallback(token) {
-    console.error('First line in the function')
     try {
-      console.error('Inside the try block')
       // I don't know if we should be disabling CSRF for this one, but we'll just use it
       const csrfToken = document.querySelector("[name='csrf-token']");
-
-      console.error('Before making call to /challenge')
   
       const response = await fetch('<%= bot_detect_challenge_path %>', {
         method: 'POST',
@@ -36,26 +32,18 @@
         },
         body: JSON.stringify({ cf_turnstile_response: token }),
       });
-
-      console.error('After making call to /challenge')
   
       if (!response.ok) {
-        console.error('Response was not okay')
         throw new Error('bad response: ' + response.status + ": " + response.url);
       }
 
-      console.error("Testing")
-  
       result = await response.json();
       if (result["redirect_for_challenge"] == true) {
-        console.error("Hello Connor")
         const dest = new URLSearchParams(window.location.search).get("dest");
         // For security make sure it only has path and on
         if (!dest.startsWith("/") || dest.startsWith("//")) {
           throw new Error("illegal non-local redirect: " + dest);
         }
-
-        console.error("before window.location.replace")
 
         // replace the challenge page in history
         window.location.replace(dest);

--- a/app/views/bot_detect/challenge.html.erb
+++ b/app/views/bot_detect/challenge.html.erb
@@ -1,67 +1,67 @@
 <% content_for(:head) do %>
-    <script src="<%= cf_turnstile_js_url %>" async defer></script>
-    <meta name="robots" content="noindex">
-  <% end %>
+  <script src="<%= cf_turnstile_js_url %>" async defer></script>
+  <meta name="robots" content="noindex">
+<% end %>
   
   
-  <h1 class="brand-alt-h1 mb-4">Traffic control and bot detection...</h2>
+<h1 class="brand-alt-h1 mb-4">Traffic control and bot detection...</h2>
   
-  <div
-    class="cf-turnstile"
-    data-sitekey="<%= cf_turnstile_sitekey %>"
-    data-callback="turnstileCallback"
-  ></div>
+<div
+  class="cf-turnstile"
+  data-sitekey="<%= cf_turnstile_sitekey %>"
+  data-callback="turnstileCallback"
+></div>
   
-  <noscript>
-    <div class="alert alert-danger">Sorry, Javascript is required to be enabled for our traffic check, and does not appear available.</div>
-  </noscript>
+<noscript>
+  <div class="alert alert-danger">Sorry, Javascript is required to be enabled for our traffic check, and does not appear available.</div>
+</noscript>
   
-  <p>We strive to make our content freely available. If this check is preventing you from making use of our resources, make sure you have cookies enabled. If you still have trouble, please <a href="mailto:digital@sciencehistory.org">get in touch</a>. You can also take a look at our information on <a href="https://digital.sciencehistory.org/api_docs">API and Machine Access</a>.</p>
+<p>We strive to make our content freely available. If this check is preventing you from making use of our resources, make sure you have cookies enabled. If you still have trouble, please <a href="mailto:digital@sciencehistory.org">get in touch</a>. You can also take a look at our information on <a href="https://digital.sciencehistory.org/api_docs">API and Machine Access</a>.</p>
   
-  <script type="text/javascript">
-    async function turnstileCallback(token) {
-      try {
-        // I don't know if we should be disabling CSRF for this one, but we'll just use it
-        const csrfToken = document.querySelector("[name='csrf-token']");
+<script type="text/javascript">
+  async function turnstileCallback(token) {
+    try {
+      // I don't know if we should be disabling CSRF for this one, but we'll just use it
+      const csrfToken = document.querySelector("[name='csrf-token']");
   
-        const response = await fetch('<%= bot_detect_challenge_path %>', {
-          method: 'POST',
-          headers: {
-            "X-CSRF-Token": csrfToken?.content,
-            "Content-Type": "application/json"
-          },
-          body: JSON.stringify({ cf_turnstile_response: token }),
-        });
+      const response = await fetch('<%= bot_detect_challenge_path %>', {
+        method: 'POST',
+        headers: {
+          "X-CSRF-Token": csrfToken?.content,
+          "Content-Type": "application/json"
+        },
+        body: JSON.stringify({ cf_turnstile_response: token }),
+      });
   
-        if (!response.ok) {
-          throw new Error('bad response: ' + response.status + ": " + response.url);
+      if (!response.ok) {
+        throw new Error('bad response: ' + response.status + ": " + response.url);
+      }
+  
+      result = await response.json();
+      if (result["success"] == true) {
+        const dest = new URLSearchParams(window.location.search).get("dest");
+        // For security make sure it only has path and on
+        if (!dest.startsWith("/") || dest.startsWith("//")) {
+          throw new Error("illegal non-local redirect: " + dest);
         }
-  
-        result = await response.json();
-        if (result["success"] == true) {
-          const dest = new URLSearchParams(window.location.search).get("dest");
-          // For security make sure it only has path and on
-          if (!dest.startsWith("/") || dest.startsWith("//")) {
-            throw new Error("illegal non-local redirect: " + dest);
-          }
-          // replace the challenge page in history
-          window.location.replace(dest);
-        } else {
-          console.error("Turnstile response reported as failure: " + JSON.stringify(result))
-          _displayChallengeError();
-        }
-      } catch(error) {
-        console.error("Error processing turnstile challenge backend action: " + error);
+        // replace the challenge page in history
+        window.location.replace(dest);
+      } else {
+        console.error("Turnstile response reported as failure: " + JSON.stringify(result))
         _displayChallengeError();
       }
+    } catch(error) {
+      console.error("Error processing turnstile challenge backend action: " + error);
+      _displayChallengeError();
     }
+  }
   
-    function _displayChallengeError() {
-      document.querySelector(".cf-turnstile").outerHTML = `
-        <div class="alert alert-danger" role="alert">
-          <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
-          Check failed. Sorry, something has gone wrong, or your traffic looks unusual to us. You can try refreshing this page to try again.
-        </div>
-      `;
-    }
-  </script>
+  function _displayChallengeError() {
+    document.querySelector(".cf-turnstile").outerHTML = `
+      <div class="alert alert-danger" role="alert">
+        <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
+        Check failed. Sorry, something has gone wrong, or your traffic looks unusual to us. You can try refreshing this page to try again.
+      </div>
+    `;
+  }
+</script>

--- a/app/views/bot_detect/challenge.html.erb
+++ b/app/views/bot_detect/challenge.html.erb
@@ -20,9 +20,13 @@
   
 <script type="text/javascript">
   async function turnstileCallback(token) {
+    console.error('First line in the function')
     try {
+      console.error('Inside the try block')
       // I don't know if we should be disabling CSRF for this one, but we'll just use it
       const csrfToken = document.querySelector("[name='csrf-token']");
+
+      console.error('Before making call to /challenge')
   
       const response = await fetch('<%= bot_detect_challenge_path %>', {
         method: 'POST',
@@ -32,8 +36,11 @@
         },
         body: JSON.stringify({ cf_turnstile_response: token }),
       });
+
+      console.error('After making call to /challenge')
   
       if (!response.ok) {
+        console.error('Response was not okay')
         throw new Error('bad response: ' + response.status + ": " + response.url);
       }
 

--- a/app/views/bot_detect/challenge.html.erb
+++ b/app/views/bot_detect/challenge.html.erb
@@ -36,6 +36,8 @@
       if (!response.ok) {
         throw new Error('bad response: ' + response.status + ": " + response.url);
       }
+
+      console.error("Testing")
   
       result = await response.json();
       if (result["redirect_for_challenge"] == true) {

--- a/app/views/bot_detect/challenge.html.erb
+++ b/app/views/bot_detect/challenge.html.erb
@@ -38,7 +38,7 @@
       }
   
       result = await response.json();
-      if (result["success"] == true) {
+      if (result["redirect_for_challenge"] == true) {
         const dest = new URLSearchParams(window.location.search).get("dest");
         // For security make sure it only has path and on
         if (!dest.startsWith("/") || dest.startsWith("//")) {

--- a/app/views/bot_detect/challenge.html.erb
+++ b/app/views/bot_detect/challenge.html.erb
@@ -16,7 +16,7 @@
   <div class="alert alert-danger">Sorry, Javascript is required to be enabled for our traffic check, and does not appear available.</div>
 </noscript>
   
-<p>We strive to make our content freely available. If this check is preventing you from making use of our resources, make sure you have cookies enabled. If you still have trouble, please <a href="mailto:digital@sciencehistory.org">get in touch</a>. You can also take a look at our information on <a href="https://digital.sciencehistory.org/api_docs">API and Machine Access</a>.</p>
+<p>We strive to make our content freely available. If this check is preventing you from making use of our resources, make sure you have cookies enabled. If you still have trouble, please <a href="<%= contact_us_url() %>">get in touch</a>.</p>
   
 <script type="text/javascript">
   async function turnstileCallback(token) {

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -32,7 +32,7 @@
 <%= javascript_include_tag 'application' %>
 <script src="https://cdn.ckeditor.com/4.11.4/standard/ckeditor.js"></script>
 <%= csrf_meta_tags %>
-<%= content_for(:head) %>
+<%= yield :head %>
 <%= favicon_link_tag 'favicon.ico' %>
 
 <% if @link_alternate %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -32,6 +32,7 @@
 <%= javascript_include_tag 'application' %>
 <script src="https://cdn.ckeditor.com/4.11.4/standard/ckeditor.js"></script>
 <%= csrf_meta_tags %>
+<%= content_for(:head) %>
 <%= favicon_link_tag 'favicon.ico' %>
 
 <% if @link_alternate %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,6 +39,9 @@ Rails.application.routes.draw do
   get 'search/advanced' => 'search#advanced', as: :search_advanced
   get 'search' => 'search#index', as: :search
 
+  # bot detection challenge
+  get "/challenge", to: "bot_detect#challenge", as: :bot_detect_challenge
+  post "/challenge", to: "bot_detect#verify_challenge"
 
   # VIVO original URLs
   get 'people' => 'home#people'


### PR DESCRIPTION
Bot traffic on vivo faceting was too high and was crashing the site. We decided to implement [Cloudflare Turnstile](https://www.cloudflare.com/application-services/products/turnstile/)(affectionately, cloudstile turnflare) on the search pages. This adds a human check before you can access the page. The check can be a javascript challenge which runs in the background or a checkbox which requires human intervention. 

We based this implementation on [jrochkind's PR](https://github.com/sciencehistory/scihist_digicoll/pull/2838/files) that implements Turnstile on a blacklight based site, as well as his [blog post](https://bibwild.wordpress.com/2025/01/16/using-cloudflare-turnstile-to-protect-certain-pages-on-a-rails-app/) and the [gem](https://github.com/samvera-labs/bot_challenge_page) he released. We may try to install the gem in the future because it has extra features, but for now we wanted the most minimal possible implementation, and we weren't confident the gem would install correctly. We also kept a lot of commented out code from jrochkind's PR because we might want to use it in the future.

The way it works is whenever the search page gets a request, the SearchController runs a `before action` which calls the BotDetectController. The bot detect controller checks for a valid session cookie indicating that the user has already been challenged and passed. If it finds that cookie, it returns the flow back to the search controller and the page displays.

Otherwise, it redirects the user to a new /challenge page which displays the turnstile javascript challenge. Once the user passes the challenge, we set the session cookie and they are redirected to the search page (which runs the same before action, but now finds the session cookie and just displays the page). Otherwise they receive a failure page and are not redirected. 